### PR TITLE
Switch from goccy/go-json to benitogf/go-json

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/goccy/go-json"
+	"github.com/benitogf/go-json"
 )
 
 func BenchmarkCreatePatchSimpleObject(b *testing.B) {

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/benitogf/jsonpatch
 go 1.19
 
 require (
+	github.com/benitogf/go-json v0.0.0-20260410172501-727f5690408b
 	github.com/benitogf/jsondiff v0.0.0-20200402083139-355fc2c95658
-	github.com/goccy/go-json v0.9.11
 	github.com/stretchr/testify v1.6.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
+github.com/benitogf/go-json v0.0.0-20260410172501-727f5690408b h1:EXDsF3gMYyR8ipJsGuyHB4d3+XovPT8d4UM6cfBII14=
+github.com/benitogf/go-json v0.0.0-20260410172501-727f5690408b/go.mod h1:bv78ZxbWzHLAwEcSgQNjDUVgl3F4nOuYln98xHfUyjw=
 github.com/benitogf/jsondiff v0.0.0-20200402083139-355fc2c95658 h1:wCbyHDE170Pt3F2YcJn9Q82ed9f/PB2YE4lYRDvJLf4=
 github.com/benitogf/jsondiff v0.0.0-20200402083139-355fc2c95658/go.mod h1:w/Y8qUTRw+ewq+K23wa0CrhT19d1nsboJd8mFJoE9+0=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/goccy/go-json v0.9.11 h1:/pAaQDLHEoCq/5FFmSKBswWmK6H0e8g4159Kc/X/nqk=
-github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/jsonpatch.go
+++ b/jsonpatch.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/goccy/go-json"
+	"github.com/benitogf/go-json"
 )
 
 var errBadMergeTypes = fmt.Errorf("mismatched json documents")

--- a/jsonpatch_complex_test.go
+++ b/jsonpatch_complex_test.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/goccy/go-json"
+	"github.com/benitogf/go-json"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/jsonpatch_edge_test.go
+++ b/jsonpatch_edge_test.go
@@ -3,7 +3,7 @@ package jsonpatch
 import (
 	"testing"
 
-	"github.com/goccy/go-json"
+	"github.com/benitogf/go-json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/jsonpatch_geojson_test.go
+++ b/jsonpatch_geojson_test.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/goccy/go-json"
+	"github.com/benitogf/go-json"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/jsonpatch_simple_test.go
+++ b/jsonpatch_simple_test.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/goccy/go-json"
+	"github.com/benitogf/go-json"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/patch.go
+++ b/patch.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/goccy/go-json"
+	"github.com/benitogf/go-json"
 )
 
 const (

--- a/patch_test.go
+++ b/patch_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/goccy/go-json"
+	"github.com/benitogf/go-json"
 
 	"github.com/benitogf/jsondiff"
 )


### PR DESCRIPTION
Replace goccy/go-json with benitogf/go-json fork that fixes data race in encoder/decoder compiler cache (goccy/go-json#566).

Changes:
- Updated all imports in .go files (8 files)
- Updated go.mod dependency
- All tests pass